### PR TITLE
Resizable pane

### DIFF
--- a/src/components/laserweb.js
+++ b/src/components/laserweb.js
@@ -13,7 +13,7 @@ import '../styles/index.css'
 
 import ReactDOM from 'react-dom'
 
-import 'jquery-resizable-dom/dist/jquery-resizable.js'
+import 'jquery-resizable-dom/dist/jquery-resizable.min.js'
 
 // React/Redux
 import React from 'react'

--- a/src/components/laserweb.js
+++ b/src/components/laserweb.js
@@ -10,7 +10,10 @@ import 'bootstrap'
 import 'bootstrap/dist/css/bootstrap.min.css'
 import 'font-awesome/css/font-awesome.min.css'
 import '../styles/index.css'
-import 'jquery-resizable-dom/dist/jquery-resizable.min.js'
+
+import ReactDOM from 'react-dom'
+
+import 'jquery-resizable-dom/dist/jquery-resizable.js'
 
 // React/Redux
 import React from 'react'
@@ -43,7 +46,7 @@ class LaserWeb extends React.Component {
     render() {
         return (
             <div className="full-height splitpane">
-                <Sidebar>
+                <Sidebar ref="sidebar">
                     <Com id="com" title="Communication" icon="plug" />
                     <Jog id="jog" title="Jog" icon="arrows-alt" />
                     <Cam id="cam" title="CAM" icon="pencil-square-o" />
@@ -58,12 +61,20 @@ class LaserWeb extends React.Component {
         )
     }
     
-    componentDidMount() {
-      $("#sidebar").resizable({
-        handleSelector: ".splitter",
-        resizeHeight: false
-      });
+    componentDidMount()
+    {
+        this._splitpane();
     }
+    
+    _splitpane() {
+        var self=ReactDOM.findDOMNode(this.refs.sidebar);
+        $(self).resizable({
+          handleSelector: $(self).siblings(".splitter"),
+          resizeHeight: false
+        })
+    }
+   
+    
 }
 
 // Exports

--- a/src/components/panes.js
+++ b/src/components/panes.js
@@ -74,6 +74,10 @@ class Panes extends React.Component {
             </div>
         )
     }
+    
+    componentWillUpdate(newProps,newState) {
+         this.props.onVisibleChange(newProps.visible);
+    }
 }
 
 const mapStateToProps = (state) => {

--- a/src/components/sidebar.js
+++ b/src/components/sidebar.js
@@ -29,18 +29,34 @@ class Sidebar extends React.Component {
      * @property {module:react~React~Component|module:react~React~Component[]} children Component children.
      */
 
+    constructor(props) {
+        super(props);
+        
+        this.state={
+            visible:true
+        }
+        
+        this.handleChange = this.handleChange.bind(this);
+    }
+     
+     
     /**
      * Render the component.
      * @return {String}
      */
     render() {
         return (
-            <div id="sidebar" className="full-height">
+            <div id="sidebar" className={"full-height "+ (this.state.visible ? "" : "folded")} >
                 <Dock>{this.props.children}</Dock>
-                <Panes>{this.props.children}</Panes>
+                <Panes ref="panes" onVisibleChange={this.handleChange} >{this.props.children}</Panes>
             </div>
         )
     }
+    
+    handleChange(e) {
+       this.setState({visible: e});
+    }
+
 }
 
 export default Sidebar

--- a/src/components/workspace.js
+++ b/src/components/workspace.js
@@ -133,6 +133,7 @@ class WorkspaceContent extends React.Component {
                         height={this.props.height}
                         pixelRatio={window.devicePixelRatio}
                         clearColor={0x00ffffff}
+                        alpha={true}
                         >
                         <scene>
                             <perspectiveCamera

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -152,3 +152,8 @@ body, html, .full-height {
   border-left: 1px #ccc dashed;
   border-right: 1px #ccc dashed;
 }
+
+#sidebar.folded {
+    flex-grow:0;
+    max-width:0;
+}


### PR DESCRIPTION
Now the resizable pane is fully collapsible (click on active pane to collapse the sidebar)
I've had hard time with propagation of states/props between components, but boiled down to few lines after all.
I've included a minor fix on #15 (refresh black glitch).